### PR TITLE
Fixed uninitialized variable use

### DIFF
--- a/src/ctserial/commands.py
+++ b/src/ctserial/commands.py
@@ -137,11 +137,11 @@ class Commands(object):
         """Send data to serial device"""
         # clear out any leftover data
         try:
+            rx_raw = bytes()
             if session.inWaiting() > 0:
                 session.flushInput()
             session.write(tx_bytes)
             time.sleep(0.1)
-            rx_raw = bytes()
             while session.inWaiting() > 0:
                 rx_raw += session.read()
         except BaseException as e:


### PR DESCRIPTION
Fixed a bug where if an exception was thrown within _send_instruction the rx_raw variable would be uninitialized causing another exception to be thrown.
Note that currently the function doesn't propagate the error.
I suggest removing the exception handling from the function as there is not mush you can do in this scope.